### PR TITLE
IPBlock: Store given IP address part from constructor and make it possible to return it.

### DIFF
--- a/src/IPBlock.php
+++ b/src/IPBlock.php
@@ -17,6 +17,11 @@ abstract class IPBlock implements Iterator, ArrayAccess, Countable
 	/**
 	 * @var IP
 	 */
+	protected $given_ip;
+
+	/**
+	 * @var IP
+	 */
 	protected $first_ip;
 
 	/**
@@ -112,25 +117,37 @@ abstract class IPBlock implements Iterator, ArrayAccess, Countable
 	 */
 	public function __construct($ip_or_cidr, $prefix = '')
 	{
-		$ip = $ip_or_cidr;
+		$this->given_ip = $ip_or_cidr;
 		if ( strpos($ip_or_cidr, '/') !== false ) {
-			list($ip, $prefix) = explode('/', $ip_or_cidr, 2);
+			list($this->given_ip, $prefix) = explode('/', $ip_or_cidr, 2);
 		}
 
-		if ( ! $ip instanceof IP ) {
-			$ip = new $this->ip_class($ip);
+		if ( ! $this->given_ip instanceof IP ) {
+			$this->given_ip = new $this->ip_class($this->given_ip);
 		}
 
 		$this->checkPrefix($prefix);
 		$this->prefix = (int) $prefix;
 
-		$this->first_ip = $ip->bit_and($this->getMask());
+		$this->first_ip = $this->given_ip->bit_and($this->getMask());
 		$this->last_ip = $this->first_ip->bit_or($this->getDelta());
 	}
 
 	public function __toString()
 	{
 		return (string) $this->first_ip.'/'.$this->prefix;
+	}
+
+	/**
+	 * Returns given IP.
+	 *
+	 * For example 192.168.48.7 for 192.168.48.7/24
+	 *
+	 * @return IP
+	 */
+	public function getGivenIp()
+	{
+		return $this->given_ip;
 	}
 
 	/**
@@ -245,6 +262,26 @@ abstract class IPBlock implements Iterator, ArrayAccess, Countable
 	public function getBroadcastAddress()
 	{
 		return $this->last_ip;
+	}
+
+	/**
+	 * A string representation of the given IP with the mask in prefix notation
+	 *
+	 * @return string
+	 */
+	public function getGivenIpWithPrefixlen()
+	{
+		return $this->given_ip . "/" . $this->prefix;
+	}
+
+	/**
+	 * A string representation of the given IP with the network as a net mask.
+	 *
+	 * @return string
+	 **/
+	public function getGivenIpWithNetmask()
+	{
+		return $this->given_ip . "/" . $this->getMask();
 	}
 
 	/**


### PR DESCRIPTION
With these change you can use these classes like mostly like python IPv4Interface() or IPv6Interface().

I had the need to parse IP addresses in the form of 192.168.48.7/24 or 2001:abcd::23/64, verify them, get the IP part, get the network address of them, and to check if other IP like (gw) 192.168.48.1 are in the same subnet.

Instead of writing a new class when this already handles 95% of my needs I chose to extend it a little bit.
