### PR TITLE
Test IPBlock::getSubblocks()

### DIFF
--- a/src/IPBlockIterator.php
+++ b/src/IPBlockIterator.php
@@ -15,7 +15,7 @@ namespace PhpIP;
 /**
  * Iterator for IPBlock. This could be a Generator in PHP 5.5.
  */
-class IPBlockIterator implements \Iterator
+class IPBlockIterator implements \Iterator, \Countable
 {
     /**
      * @var int|\GMP
@@ -47,7 +47,9 @@ class IPBlockIterator implements \Iterator
         $this->class = get_class($first_block);
 
         $this->first_block = $first_block;
+        $this->current_block = $first_block;
         $this->nb_blocks = $nb_blocks;
+        $this->position = gmp_init(0);
     }
 
     public function count()

--- a/tests/IPBlockTest.php
+++ b/tests/IPBlockTest.php
@@ -189,7 +189,17 @@ class IPBlockTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSubblocks()
     {
-        // todo
+        $block = IPBlock::create('192.168.8.0/24');
+        $subnets = $block->getSubblocks('/28');
+
+        $this->assertCount(16, $subnets);
+        $this->assertEquals('192.168.8.0', $subnets->current()->getFirstIp()->humanReadable());
+        $this->assertEquals(28, $subnets->current()->getPrefix());
+
+        $subnets->next();
+        $subnets->next();
+
+        $this->assertEquals('192.168.8.32/28', $subnets->current()->getGivenIpWithPrefixlen());
     }
 
     public function testGetSuper()


### PR DESCRIPTION
When writing the test for getSubblocks, it was identified that the IPBlockIterator did not work as expected.
`$current_block` and `$position` need to be instantiated in the constructor.

While and iterator is "countable", without implementing the `\Countable` interface, the state of the object would change if the `count()` functions is called, specifically the position would be set to the last block.