### PR TITLE
Change method names.

### DIFF
--- a/src/IPBlock.php
+++ b/src/IPBlock.php
@@ -297,7 +297,7 @@ abstract class IPBlock implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @return string
      */
-    public function getGivenIpWithPrefixlen(): string
+    public function getGivenIpWithPrefixLen(): string
     {
         return $this->given_ip.'/'.$this->prefix;
     }
@@ -340,7 +340,7 @@ abstract class IPBlock implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @return IPBlockIterator
      */
-    public function getSubblocks($prefix): IPBlockIterator
+    public function getSubBlocks($prefix): IPBlockIterator
     {
         $prefix = ltrim($prefix, '/');
         $this->checkPrefix($prefix);
@@ -356,13 +356,27 @@ abstract class IPBlock implements \ArrayAccess, \IteratorAggregate, \Countable
     }
 
     /**
-     * Return the superblock containing the current block.
+     * @deprecated since version 2.0 and will be removed in 3.0. Use IPBlock::getSuperBlock() instead.
      *
      * @param mixed $prefix
      *
      * @return IPBlock
      */
     public function getSuper($prefix): IPBlock
+    {
+        @trigger_error('IPBlock::getSuper() is deprecated since version 2.0 and will be removed in 3.0. Use IPBlock::getSuperBlock() instead.', E_USER_DEPRECATED);
+
+        return $this->getSuperBlock($prefix);
+    }
+
+    /**
+     * Return the super block containing the current block.
+     *
+     * @param mixed $prefix
+     *
+     * @return IPBlock
+     */
+    public function getSuperBlock($prefix): IPBlock
     {
         $prefix = ltrim($prefix, '/');
         $this->checkPrefix($prefix);

--- a/tests/IPBlockTest.php
+++ b/tests/IPBlockTest.php
@@ -243,10 +243,10 @@ class IPBlockTest extends TestCase
         }
     }
 
-    public function testGetSubblocks()
+    public function testGetSubBlocks()
     {
         $block = IPBlock::create('192.168.8.0/24');
-        $subnets = $block->getSubblocks('/28');
+        $subnets = $block->getSubBlocks('/28');
 
         $this->assertCount(16, $subnets);
         $this->assertEquals('192.168.8.0', $subnets->current()->getFirstIp()->humanReadable());
@@ -255,22 +255,22 @@ class IPBlockTest extends TestCase
         $subnets->next();
         $subnets->next();
 
-        $this->assertEquals('192.168.8.32/28', $subnets->current()->getGivenIpWithPrefixlen());
+        $this->assertEquals('192.168.8.32/28', $subnets->current()->getGivenIpWithPrefixLen());
     }
 
-    public function testGetSuper()
+    public function testGetSuperBlock()
     {
         $block = IPBlock::create('192.168.42.0/24');
-        $this->assertEquals('192.168.0.0/16', (string) $block->getSuper('/16'));
+        $this->assertEquals('192.168.0.0/16', (string) $block->getSuperBlock('/16'));
 
         try {
-            $block->getSuper('');
+            $block->getSuperBlock('');
             $this->fail('Expected InvalidArgumentException has not be thrown');
         } catch (\InvalidArgumentException $e) {
         }
 
         try {
-            $block->getSuper('/32');
+            $block->getSuperBlock('/32');
             $this->fail('Expected InvalidArgumentException has not be thrown');
         } catch (\InvalidArgumentException $e) {
         }


### PR DESCRIPTION
Addresses issue #20 
* Use camel case (no need for deprecation as functions are case-insensitive).
* Rename `getSuper` to `getSuperBlock` and deprecate old method.