### PR TITLE
Add method IPv4::isNetmask()

### DIFF
--- a/src/IPv4.php
+++ b/src/IPv4.php
@@ -51,6 +51,11 @@ class IPv4 extends IP
     protected static $link_local_block = '169.254.0.0/16';
 
     /**
+     * @var bool
+     */
+    protected $is_netmask;
+
+    /**
      * {@inheritdoc}
      */
     public function humanReadable(bool $short_form = true): string
@@ -72,5 +77,27 @@ class IPv4 extends IP
         $octets = array_reverse(explode('.', $this->humanReadable()));
 
         return implode('.', $octets).'.in-addr.arpa.';
+    }
+
+    /**
+     * Return true if the IP address is a valid sub network mask, for instance: '255.255.252.0'.
+     *
+     * @return bool
+     */
+    public function isNetmask(): bool
+    {
+        if ($this->is_netmask !== null) {
+            return $this->is_netmask;
+        }
+
+        if (gmp_cmp($this->ip, 0) === 0) {
+            $this->is_netmask = true;
+        } else {
+            $y = $this->bit_negate()->plus(1);
+            $z = $this->bit_negate()->bit_and($y);
+            $this->is_netmask = gmp_cmp($z->ip, 0) === 0;
+        }
+
+        return $this->is_netmask;
     }
 }

--- a/tests/IPv4Test.php
+++ b/tests/IPv4Test.php
@@ -220,6 +220,27 @@ class IPv4Test extends TestCase
     }
 
     /**
+     * Data provider for testIsNetmask().
+     *
+     * @return array
+     */
+    public function netmaskProvider(): array
+    {
+        return [
+            //IP address        is valid netmask
+            ['0.0.0.0',         true],
+            ['64.0.0.0',        false],
+            ['128.0.0.0',       true],
+            ['127.0.0.0',       false],
+            ['255.255.0.0',     true],
+            ['255.0.255.252',   false],
+            ['255.255.255.0',   true],
+            ['255.255.255.224', true],
+            ['255.255.255.252', true],
+        ];
+    }
+
+    /**
      * @dataProvider validAddresses
      */
     public function testConstructValid($ip, $string)
@@ -516,5 +537,16 @@ class IPv4Test extends TestCase
 
         $this->assertTrue($ip->matches('172.16.3.5'));
         $this->assertFalse($ip->matches('172.16.3.4'));
+    }
+
+    /**
+     * @dataProvider netmaskProvider
+     *
+     * @param $ip
+     * @param bool $expectation
+     */
+    public function testIsNetMask($ip, bool $expectation)
+    {
+        $this->assertEquals($expectation, IPv4::create($ip)->isNetmask());
     }
 }


### PR DESCRIPTION
Add new method IPv4::isNetmask().

This provides functionality to test if an IPv4 address is a valid netmask.