### PR TITLE
IANA Aligned PRIVATE/RESERVED Blocks -- resolves rlanvin/php-ip#67

### DIFF
--- a/src/IP.php
+++ b/src/IP.php
@@ -73,6 +73,11 @@ abstract class IP
     /**
      * @var bool
      */
+    protected $is_reserved;
+
+    /**
+     * @var bool
+     */
     protected $is_link_local;
 
     /**
@@ -485,9 +490,11 @@ abstract class IP
     }
 
     /**
-     * Return true if the address is reserved per IANA IPv4/6 Special Registry.
+     * Return true if the address is reserved per IANA IPv4/6 Special Registry
+     * and is not global reachable, but routeable.
      *
-     * @see https://en.wikipedia.org/wiki/Reserved_IP_addresses
+     * @see https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+     * @see https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
      *
      * @return bool
      */
@@ -510,13 +517,39 @@ abstract class IP
     }
 
     /**
+     * Return true if the address is reserved per IANA IPv4/6 Special Registry.
+     *
+     * @see https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+     * @see https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+     *
+     * @return bool
+     */
+    public function isReserved(): bool
+    {
+        if ($this->is_reserved !== null) {
+            return $this->is_reserved;
+        }
+
+        $this->is_reserved = false;
+
+        foreach ((static::BLOCK_CLASS)::getReservedBlocks() as $block) {
+            if ($block->contains($this)) {
+                $this->is_reserved = true;
+                break;
+            }
+        }
+
+        return $this->is_reserved;
+    }
+
+    /**
      * Return true if the address is allocated for public networks.
      *
      * @return bool
      */
     public function isPublic(): bool
     {
-        return !$this->isPrivate();
+        return !$this->isReserved();
     }
 
     /**

--- a/src/IPBlockTrait.php
+++ b/src/IPBlockTrait.php
@@ -24,6 +24,11 @@ trait IPBlockTrait
     static public $private_blocks = null;
 
     /**
+     * @var array Cache for the reserved blocks IPBlock instances
+     */
+    static public $reserved_blocks = null;
+
+    /**
      * Returns an array with the private blocks as IPBlock objects.
      *
      * The array is then cached so the IPBlock objects don't need to be instanciated
@@ -42,6 +47,27 @@ trait IPBlockTrait
         }
 
         return self::$private_blocks;
+    }
+
+    /**
+     * Returns an array with the IANA reserved blocks as IPBlock objects.
+     *
+     * The array is then cached so the IPBlock objects don't need to be instanciated
+     * anymore. This makes checking IP::isReserved() a lot faster if more than once
+     * in the same script.
+     *
+     * @return array An array of IPBlock
+     */
+    public static function getReservedBlocks(): array
+    {
+        if (self::$reserved_blocks === null) {
+            self::$reserved_blocks = [];
+            foreach (self::RESERVED_BLOCKS as $block) {
+                self::$reserved_blocks[] = new self($block);
+            }
+        }
+
+        return self::$reserved_blocks;
     }
 
     /**

--- a/src/IPv4Block.php
+++ b/src/IPv4Block.php
@@ -24,18 +24,42 @@ class IPv4Block extends IPBlock
     const IP_CLASS = IPv4::class;
 
     /**
-     * @see https://en.wikipedia.org/wiki/Reserved_IP_addresses
+     * @see https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+     *
+     * PRIVATE_BLOCKS   = not globally reachable, but routeable
+     * RESERVED_BLOCKS  = all IANA reserved blocks
+     * LOOPBACK_BLOCK   = Loopback Address
+     * LINK_LOCAL_BLOCK = Link-Local Unicast
      */
     const PRIVATE_BLOCKS = [
-        '0.0.0.0/8',
         '10.0.0.0/8',
+        '100.64.0.0/10',
+        '172.16.0.0/12',
+        '192.0.0.0/29',
+        '192.168.0.0/16',
+        '198.18.0.0/15'
+    ];
+    const RESERVED_BLOCKS = [
+        '0.0.0.0/8',
+        '0.0.0.0/32',
+        '10.0.0.0/8',
+        '100.64.0.0/10',
         '127.0.0.0/8',
         '169.254.0.0/16',
         '172.16.0.0/12',
+        '192.0.0.0/24',
         '192.0.0.0/29',
-        '192.0.0.170/31',
+        '192.0.0.8/32',
+        '192.0.0.9/32',
+        '192.0.0.10/32',
+        '192.0.0.170/32',
+        '192.0.0.171/32',
         '192.0.2.0/24',
+        '192.31.196.0/24',
+        '192.52.193.0/24',
+        '192.88.99.0/24',
         '192.168.0.0/16',
+        '192.175.48.0/24',
         '198.18.0.0/15',
         '198.51.100.0/24',
         '203.0.113.0/24',

--- a/src/IPv6Block.php
+++ b/src/IPv6Block.php
@@ -24,17 +24,38 @@ class IPv6Block extends IPBlock
     const IP_CLASS = IPv6::class;
 
     /**
-     * @see https://en.wikipedia.org/wiki/Reserved_IP_addresses
+     * @see https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+     *
+     * PRIVATE_BLOCKS   = not globally reachable, but routeable
+     * RESERVED_BLOCKS  = all IANA reserved blocks
+     * LOOPBACK_BLOCK   = Loopback Address
+     * LINK_LOCAL_BLOCK = Link-Local Unicast
      */
     const PRIVATE_BLOCKS = [
-        '::1/128',
+        'fc00::/7',
+        '2001:2::/48',
+        '100::/64',
+        '64:ff9b:1::/48'
+    ];
+    const RESERVED_BLOCKS = [
         '::/128',
+        '::1/128',
         '::ffff:0:0/96',
+        '64:ff9b::/96',
+        '64:ff9b:1::/48',
         '100::/64',
         '2001::/23',
+        '2001::/32',
+        '2001:1::1/128',
+        '2001:1::2/128',
         '2001:2::/48',
-        '2001:db8::/32',
+        '2001:3::/32',
+        '2001:4:112::/48',
         '2001:10::/28',
+        '2001:20::/28',
+        '2001:db8::/32',
+        '2002::/16',
+        '2620:4f:8000::/48',
         'fc00::/7',
         'fe80::/10',
     ];

--- a/tests/IPv4BlockTest.php
+++ b/tests/IPv4BlockTest.php
@@ -50,8 +50,8 @@ class IPv4BlockTest extends TestCase
         $private_blocks = IPv4Block::getPrivateBlocks();
 
         $this->assertInstanceOf(IPv4Block::class, $private_blocks[0]);
-        $this->assertEquals('0.0.0.0/8', (string) $private_blocks[0]);
-        $this->assertCount(14, $private_blocks);
+        $this->assertEquals('10.0.0.0/8', (string) $private_blocks[0]);
+        $this->assertCount(6, $private_blocks);
     }
 
     public function testGetLoopbackBlock()
@@ -68,5 +68,13 @@ class IPv4BlockTest extends TestCase
 
         $this->assertInstanceOf(IPv4Block::class, $link_local_block);
         $this->assertEquals('169.254.0.0/16', (string) $link_local_block);
+    }
+
+    public function testGetReservedBlocks()
+    {
+        $reserved_blocks = IPv4Block::getReservedBlocks();
+
+        $this->assertInstanceOf(IPv4Block::class, $reserved_blocks[0]);
+        $this->assertEquals('0.0.0.0/8', (string) $reserved_blocks[0]);
     }
 }

--- a/tests/IPv4Test.php
+++ b/tests/IPv4Test.php
@@ -314,7 +314,7 @@ class IPv4Test extends TestCase
     public function privateAddresses()
     {
         return [
-            ['127.0.0.1'],
+            ['10.0.0.1'],
             ['192.168.0.1'],
         ];
     }

--- a/tests/IPv6BlockTest.php
+++ b/tests/IPv6BlockTest.php
@@ -50,8 +50,8 @@ class IPv6BlockTest extends TestCase
         $private_blocks = IPv6Block::getPrivateBlocks();
 
         $this->assertInstanceOf(IPv6Block::class, $private_blocks[0]);
-        $this->assertEquals('::1/128', (string) $private_blocks[0]);
-        $this->assertCount(10, $private_blocks);
+        $this->assertEquals('fc00::/7', (string) $private_blocks[0]);
+        $this->assertCount(4, $private_blocks);
     }
 
     public function testGetLoopbackBlock()
@@ -68,5 +68,13 @@ class IPv6BlockTest extends TestCase
 
         $this->assertInstanceOf(IPv6Block::class, $link_local_block);
         $this->assertEquals('fe80::/10', (string) $link_local_block);
+    }
+
+    public function testGetReservedBlocks()
+    {
+        $reserved_blocks = IPv6Block::getReservedBlocks();
+
+        $this->assertInstanceOf(IPv6Block::class, $reserved_blocks[0]);
+        $this->assertEquals('::/128', (string) $reserved_blocks[0]);
     }
 }


### PR DESCRIPTION
### Add
* add RESERVED_BLOCKS to all IANA special registry prefixes / blocks
* add method `::getReservedBlocks()`
* add method `IP::isReserved()` 
### Changes
* changes PRIVATE_BLOCKS to non-global, route-able prefixes / blocks
* changes method `::isPublic()` to use `::isReserved()` instead of `::isPublic()`
### Fixes
* fix unit tests for given changes
